### PR TITLE
Turn the start of night and day into distinct turns

### DIFF
--- a/app/Werewolf/Commands/Start.hs
+++ b/app/Werewolf/Commands/Start.hs
@@ -22,6 +22,7 @@ module Werewolf.Commands.Start (
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Writer
+import Control.Monad.State
 
 import Data.Text (Text)
 
@@ -48,7 +49,7 @@ handle callerName (Options extraRoleNames playerNames) = do
 
         players <- createPlayers playerNames extraRoles
 
-        runWriterT $ startGame callerName players
+        runWriterT $ startGame callerName players >>= execStateT checkTurn
 
     case result of
         Left errorMessages      -> exitWith failure { messages = errorMessages }

--- a/src/Game/Werewolf/Command.hs
+++ b/src/Game/Werewolf/Command.hs
@@ -73,6 +73,8 @@ pingCommand = Command $ use turn >>= \turn' -> case turn' of
         tell [waitingOnMessage Nothing $ filter (flip Map.notMember (game ^. votes) . _name) (filterAlive $ game ^. players)]
     Werewolves  -> tell [pingWerewolvesMessage]
     NoOne       -> return ()
+    NightFalling -> return ()
+    DayBreaking  -> return ()
 
 quitCommand :: Text -> Command
 quitCommand callerName = Command $ do

--- a/src/Game/Werewolf/Command.hs
+++ b/src/Game/Werewolf/Command.hs
@@ -109,6 +109,8 @@ statusCommand callerName = Command $ use turn >>= \turn' -> case turn' of
         case aliveAllegiances of
             [allegiance]    -> tell [gameOverMessage . Just . T.pack $ show allegiance]
             _               -> tell [gameOverMessage Nothing]
+    NightFalling -> return ()
+    DayBreaking  -> return ()
     where
         standardStatusMessages turn players = [
             currentTurnMessage callerName turn,

--- a/src/Game/Werewolf/Engine.hs
+++ b/src/Game/Werewolf/Engine.hs
@@ -68,6 +68,12 @@ checkTurn = get >>= \game -> checkTurn' >> get >>= \game' -> unless (game == gam
 
 checkTurn' :: (MonadState Game m, MonadWriter [Message] m) => m ()
 checkTurn' = use turn >>= \turn' -> case turn' of
+    NightFalling -> do
+        advanceTurn
+
+    DayBreaking -> do
+        advanceTurn
+
     Seers -> do
         seersCount  <- uses players (length . filterAlive . filterSeers)
         votes'      <- use sees
@@ -105,8 +111,6 @@ checkTurn' = use turn >>= \turn' -> case turn' of
                     killPlayer target
                     tell [playerLynchedMessage (target ^. name) (target ^. role . Role.name)]
 
-            tell [nightFallsMessage]
-
             advanceTurn
 
     Werewolves -> do
@@ -140,7 +144,7 @@ advanceTurn = do
 
     let nextTurn = if length (nub $ map (_allegiance . _role) alivePlayers) <= 1
         then NoOne
-        else head . drop1 $ filter (turnAvailable $ map _role alivePlayers) (dropWhile (turn' /=) turnRotation)
+        else head $ filter (turnAvailable $ map _role alivePlayers) (drop1 $ dropWhile (turn' /=) turnRotation)
 
     tell $ turnMessages nextTurn alivePlayers
 

--- a/src/Game/Werewolf/Engine.hs
+++ b/src/Game/Werewolf/Engine.hs
@@ -68,11 +68,9 @@ checkTurn = get >>= \game -> checkTurn' >> get >>= \game' -> unless (game == gam
 
 checkTurn' :: (MonadState Game m, MonadWriter [Message] m) => m ()
 checkTurn' = use turn >>= \turn' -> case turn' of
-    NightFalling -> do
-        advanceTurn
+    NightFalling -> advanceTurn
 
-    DayBreaking -> do
-        advanceTurn
+    DayBreaking -> advanceTurn
 
     Seers -> do
         seersCount  <- uses players (length . filterAlive . filterSeers)

--- a/src/Game/Werewolf/Engine.hs
+++ b/src/Game/Werewolf/Engine.hs
@@ -92,7 +92,7 @@ checkTurn' = use turn >>= \turn' -> case turn' of
                 Nothing                -> do
                     aliveScapegoats <- uses players (filterAlive . filterScapegoats)
 
-                    let mScapegoat = only $ aliveScapegoats
+                    let mScapegoat = only aliveScapegoats
                     case mScapegoat of
                         Nothing        -> tell [noPlayerLynchedMessage]
                         Just scapegoat -> do

--- a/src/Game/Werewolf/Game.hs
+++ b/src/Game/Werewolf/Game.hs
@@ -29,7 +29,6 @@ module Game.Werewolf.Game (
 
 import Control.Lens
 
-import           Data.List (intersect)
 import           Data.Map  (Map)
 import qualified Data.Map  as Map
 import           Data.Text (Text)
@@ -75,8 +74,8 @@ turnRotation :: [Turn]
 turnRotation = cycle [NightFalling, Seers, Werewolves, DayBreaking, Villagers, NoOne]
 
 turnAvailable :: [Role] -> Turn -> Bool
-turnAvailable aliveRoles NightFalling = True
-turnAvailable aliveRoles DayBreaking  = True
+turnAvailable _ NightFalling          = True
+turnAvailable _ DayBreaking           = True
 turnAvailable aliveRoles Seers        = seerRole `elem` aliveRoles
 turnAvailable _ Villagers             = True
 turnAvailable _ Werewolves            = True

--- a/src/Game/Werewolf/Game.hs
+++ b/src/Game/Werewolf/Game.hs
@@ -75,9 +75,9 @@ turnRotation :: [Turn]
 turnRotation = cycle [NightFalling, Seers, Werewolves, DayBreaking, Villagers, NoOne]
 
 turnAvailable :: [Role] -> Turn -> Bool
-turnAvailable aliveRoles NightFalling    = not . null $ intersect nocturnalRoles aliveRoles
-turnAvailable aliveRoles DayBreaking     = not . null $ intersect diurnalRoles aliveRoles
-turnAvailable aliveRoles Seers  = seerRole `elem` aliveRoles
-turnAvailable _ Villagers       = True
-turnAvailable _ Werewolves      = True
-turnAvailable _ NoOne           = False
+turnAvailable aliveRoles NightFalling = True
+turnAvailable aliveRoles DayBreaking  = True
+turnAvailable aliveRoles Seers        = seerRole `elem` aliveRoles
+turnAvailable _ Villagers             = True
+turnAvailable _ Werewolves            = True
+turnAvailable _ NoOne                 = False

--- a/src/Game/Werewolf/Game.hs
+++ b/src/Game/Werewolf/Game.hs
@@ -29,6 +29,7 @@ module Game.Werewolf.Game (
 
 import Control.Lens
 
+import           Data.List (intersect)
 import           Data.Map  (Map)
 import qualified Data.Map  as Map
 import           Data.Text (Text)
@@ -43,7 +44,7 @@ data Game = Game
     , _votes   :: Map Text Text
     } deriving (Eq, Read, Show)
 
-data Turn = Seers | Villagers | Werewolves | NoOne
+data Turn = NightFalling | DayBreaking | Seers | Villagers | Werewolves | NoOne
     deriving (Eq, Read, Show)
 
 makeLenses ''Game
@@ -71,9 +72,11 @@ isGameOver :: Game -> Bool
 isGameOver game = game ^. turn == NoOne
 
 turnRotation :: [Turn]
-turnRotation = cycle [Seers, Werewolves, Villagers, NoOne]
+turnRotation = cycle [NightFalling, Seers, Werewolves, DayBreaking, Villagers, NoOne]
 
 turnAvailable :: [Role] -> Turn -> Bool
+turnAvailable aliveRoles NightFalling    = not . null $ intersect nocturnalRoles aliveRoles
+turnAvailable aliveRoles DayBreaking     = not . null $ intersect diurnalRoles aliveRoles
 turnAvailable aliveRoles Seers  = seerRole `elem` aliveRoles
 turnAvailable _ Villagers       = True
 turnAvailable _ Werewolves      = True

--- a/src/Game/Werewolf/Game.hs
+++ b/src/Game/Werewolf/Game.hs
@@ -20,6 +20,7 @@ module Game.Werewolf.Game (
     killPlayer,
 
     -- ** Queries
+    isNightfallTurn, isDaybreakTurn,
     isSeersTurn, isVillagersTurn, isWerewolvesTurn, isGameOver,
 
     -- * Turn
@@ -57,6 +58,12 @@ newGame players = Game (head $ filter (turnAvailable aliveRoles) turnRotation) p
 
 killPlayer :: Game -> Player -> Game
 killPlayer game player = game & players %~ map (\player' -> if player' == player then player' & state .~ Dead else player')
+
+isNightfallTurn :: Game -> Bool
+isNightfallTurn game = game ^. turn == NightFalling
+
+isDaybreakTurn :: Game -> Bool
+isDaybreakTurn game = game ^. turn == DayBreaking
 
 isSeersTurn :: Game -> Bool
 isSeersTurn game = game ^. turn == Seers

--- a/src/Game/Werewolf/Response.hs
+++ b/src/Game/Werewolf/Response.hs
@@ -127,7 +127,7 @@ privateMessage :: [Text] -> Text -> Message
 privateMessage to = Message (Just to)
 
 newGameMessages :: Game -> [Message]
-newGameMessages game = [newPlayersInGameMessage players', rolesInGameMessage Nothing $ map _role players'] ++ map (newPlayerMessage players') players' ++ [nightFallsMessage] ++ turnMessages turn' players'
+newGameMessages game = [newPlayersInGameMessage players', rolesInGameMessage Nothing $ map _role players'] ++ map (newPlayerMessage players') players' ++ turnMessages turn' players'
     where
         turn'       = game ^. turn
         players'    = game ^. players

--- a/src/Game/Werewolf/Response.hs
+++ b/src/Game/Werewolf/Response.hs
@@ -148,6 +148,8 @@ newPlayerMessage players player
             | otherwise                                 = T.concat [", along with ", T.intercalate ", " (map _name $ filterWerewolves players \\ [player]), "."]
 
 turnMessages :: Turn -> [Player] -> [Message]
+turnMessages NightFalling _     = [nightFallsMessage]
+turnMessages DayBreaking _      = []
 turnMessages Seers players      = seersTurnMessages $ filter isSeer players
 turnMessages Villagers players  = villagersTurnMessage players
 turnMessages Werewolves players = werewolvesTurnMessages $ filter isWerewolf players

--- a/src/Game/Werewolf/Role.hs
+++ b/src/Game/Werewolf/Role.hs
@@ -17,7 +17,7 @@ module Game.Werewolf.Role (
     Role(..), name, allegiance, description, advice,
 
     -- ** Instances
-    allRoles, seerRole, villagerRole, werewolfRole, scapegoatRole,
+    allRoles, diurnalRoles, nocturnalRoles, seerRole, villagerRole, werewolfRole, scapegoatRole,
 
     -- ** Queries
     findByName, findByName_,
@@ -44,6 +44,12 @@ data Role = Role
 
 allRoles :: [Role]
 allRoles = [seerRole, villagerRole, werewolfRole, scapegoatRole]
+
+diurnalRoles :: [Role]
+diurnalRoles = [villagerRole, scapegoatRole]
+
+nocturnalRoles :: [Role]
+nocturnalRoles = [seerRole, werewolfRole]
 
 seerRole :: Role
 seerRole = Role

--- a/test/app/Main.hs
+++ b/test/app/Main.hs
@@ -92,8 +92,7 @@ allEngineTests = [
     testProperty "PROP: check game over advances turn" prop_checkGameOverAdvancesTurn,
     testProperty "PROP: check game over does nothing when at least two allegiances alive" prop_checkGameOverDoesNothingWhenAtLeastTwoAllegiancesAlive,
 
-    testProperty "PROP: start game starts with seers turn when seers present" prop_startGameStartsWithSeersTurnWhenSeersPresent,
-    testProperty "PROP: start game starts with werewolves turn when seers absent" prop_startGameStartsWithWerewolvesTurnWhenSeersAbsent,
+    testProperty "PROP: start game starts with nightfall turn" prop_startGameStartsWithNightfallTurn,
     testProperty "PROP: start game uses given players" prop_startGameUsesGivenPlayers,
     testProperty "PROP: start game errors unless unique player names" prop_startGameErrorsUnlessUniquePlayerNames,
     testProperty "PROP: start game errors when less than 7 players" prop_startGameErrorsWhenLessThan7Players,
@@ -110,8 +109,7 @@ allEngineTests = [
 
 allGameTests :: [TestTree]
 allGameTests = [
-    testProperty "PROP: new game starts with seers turn when seers present" prop_newGameStartsWithSeersTurnWhenSeersPresent,
-    testProperty "PROP: new game starts with werewolves turn when seers absent" prop_newGameStartsWithWerewolvesTurnWhenSeersAbsent,
+    testProperty "PROP: new game starts with nightfall turn" prop_newGameStartsWithNightfallTurn,
 
     testProperty "PROP: new game starts with sees empty" prop_newGameStartsWithSeesEmpty,
     testProperty "PROP: new game starts with votes empty" prop_newGameStartsWithVotesEmpty,

--- a/test/src/Game/Werewolf/Test/Arbitrary.hs
+++ b/test/src/Game/Werewolf/Test/Arbitrary.hs
@@ -42,6 +42,8 @@ instance Show Command where
 
 arbitraryCommand :: Game -> Gen Command
 arbitraryCommand game = case game ^. turn of
+    DayBreaking -> return noopCommand
+    NightFalling -> return noopCommand
     Seers       -> arbitrarySeeCommand game
     Villagers   -> arbitraryLynchVoteCommand game
     Werewolves  -> arbitraryDevourVoteCommand game

--- a/test/src/Game/Werewolf/Test/Engine.hs
+++ b/test/src/Game/Werewolf/Test/Engine.hs
@@ -205,10 +205,9 @@ prop_checkGameOverDoesNothingWhenAtLeastTwoAllegiancesAlive game =
             ==> not . isGameOver $ run_ checkGameOver game'
 
 prop_startGameStartsWithNightfallTurn :: [Player] -> Property
-prop_startGameStartsWithNightfallTurn players = and [
-    any isSeer players,
-    isRight . runExcept . runWriterT $ startGame "" players
-    ] ==> (fst . fromRight . runExcept . runWriterT $ startGame "" players) ^. turn == NightFalling
+prop_startGameStartsWithNightfallTurn players =
+    isRight (runExcept . runWriterT $ startGame "" players)
+    ==> isNightfallTurn (fst . fromRight . runExcept . runWriterT $ startGame "" players)
 
 prop_startGameUsesGivenPlayers :: [Player] -> Property
 prop_startGameUsesGivenPlayers players' = and [

--- a/test/src/Game/Werewolf/Test/Engine.hs
+++ b/test/src/Game/Werewolf/Test/Engine.hs
@@ -24,8 +24,7 @@ module Game.Werewolf.Test.Engine (
     prop_checkGameOverAdvancesTurn, prop_checkGameOverDoesNothingWhenAtLeastTwoAllegiancesAlive,
 
     -- * startGame
-    prop_startGameStartsWithSeersTurnWhenSeersPresent,
-    prop_startGameStartsWithWerewolvesTurnWhenSeersAbsent, prop_startGameUsesGivenPlayers,
+    prop_startGameStartsWithNightfallTurn, prop_startGameUsesGivenPlayers,
     prop_startGameErrorsUnlessUniquePlayerNames, prop_startGameErrorsWhenLessThan7Players,
     prop_startGameErrorsWhenMoreThan24Players,
 
@@ -205,18 +204,11 @@ prop_checkGameOverDoesNothingWhenAtLeastTwoAllegiancesAlive game =
             length (nub . map (_allegiance . _role) . filterAlive $ game' ^. players) > 1
             ==> not . isGameOver $ run_ checkGameOver game'
 
-prop_startGameStartsWithSeersTurnWhenSeersPresent :: [Player] -> Property
-prop_startGameStartsWithSeersTurnWhenSeersPresent players = and [
+prop_startGameStartsWithNightfallTurn :: [Player] -> Property
+prop_startGameStartsWithNightfallTurn players = and [
     any isSeer players,
     isRight . runExcept . runWriterT $ startGame "" players
-    ] ==> isSeersTurn (fst . fromRight . runExcept . runWriterT $ startGame "" players)
-
-prop_startGameStartsWithWerewolvesTurnWhenSeersAbsent :: [Player] -> Property
-prop_startGameStartsWithWerewolvesTurnWhenSeersAbsent players = and [
-    isRight . runExcept . runWriterT $ startGame "" players'
-    ] ==> isWerewolvesTurn (fst . fromRight . runExcept . runWriterT $ startGame "" players')
-    where
-        players' = filter (not . isSeer) players
+    ] ==> (fst . fromRight . runExcept . runWriterT $ startGame "" players) ^. turn == NightFalling
 
 prop_startGameUsesGivenPlayers :: [Player] -> Property
 prop_startGameUsesGivenPlayers players' = and [

--- a/test/src/Game/Werewolf/Test/Game.hs
+++ b/test/src/Game/Werewolf/Test/Game.hs
@@ -20,10 +20,8 @@ import qualified Data.Map as Map
 import Game.Werewolf.Game
 import Game.Werewolf.Player
 
-import Test.QuickCheck
-
-prop_newGameStartsWithNightfallTurn :: [Player] -> Property
-prop_newGameStartsWithNightfallTurn players = any isSeer players ==> isNightfallTurn (newGame players)
+prop_newGameStartsWithNightfallTurn :: [Player] -> Bool
+prop_newGameStartsWithNightfallTurn players = isNightfallTurn (newGame players)
 
 prop_newGameStartsWithSeesEmpty :: [Player] -> Bool
 prop_newGameStartsWithSeesEmpty players = Map.null $ newGame players ^. sees

--- a/test/src/Game/Werewolf/Test/Game.hs
+++ b/test/src/Game/Werewolf/Test/Game.hs
@@ -23,7 +23,7 @@ import Game.Werewolf.Player
 import Test.QuickCheck
 
 prop_newGameStartsWithNightfallTurn :: [Player] -> Property
-prop_newGameStartsWithNightfallTurn players = any isSeer players ==> (newGame players) ^. turn == NightFalling
+prop_newGameStartsWithNightfallTurn players = any isSeer players ==> isNightfallTurn (newGame players)
 
 prop_newGameStartsWithSeesEmpty :: [Player] -> Bool
 prop_newGameStartsWithSeesEmpty players = Map.null $ newGame players ^. sees

--- a/test/src/Game/Werewolf/Test/Game.hs
+++ b/test/src/Game/Werewolf/Test/Game.hs
@@ -8,9 +8,9 @@ Maintainer  : public@hjwylde.com
 {-# OPTIONS_HADDOCK hide, prune #-}
 
 module Game.Werewolf.Test.Game (
-    prop_newGameStartsWithSeersTurnWhenSeersPresent,
-    prop_newGameStartsWithWerewolvesTurnWhenSeersAbsent, prop_newGameStartsWithSeesEmpty,
-    prop_newGameStartsWithVotesEmpty, prop_newGameUsesGivenPlayers,
+    prop_newGameStartsWithNightfallTurn,
+    prop_newGameStartsWithSeesEmpty, prop_newGameStartsWithVotesEmpty,
+    prop_newGameUsesGivenPlayers,
 ) where
 
 import Control.Lens
@@ -22,11 +22,8 @@ import Game.Werewolf.Player
 
 import Test.QuickCheck
 
-prop_newGameStartsWithSeersTurnWhenSeersPresent :: [Player] -> Property
-prop_newGameStartsWithSeersTurnWhenSeersPresent players = any isSeer players ==> isSeersTurn (newGame players)
-
-prop_newGameStartsWithWerewolvesTurnWhenSeersAbsent :: [Player] -> Bool
-prop_newGameStartsWithWerewolvesTurnWhenSeersAbsent players = isWerewolvesTurn (newGame $ filter (not . isSeer) players)
+prop_newGameStartsWithNightfallTurn :: [Player] -> Property
+prop_newGameStartsWithNightfallTurn players = any isSeer players ==> (newGame players) ^. turn == NightFalling
 
 prop_newGameStartsWithSeesEmpty :: [Player] -> Bool
 prop_newGameStartsWithSeesEmpty players = Map.null $ newGame players ^. sees


### PR DESCRIPTION
They immediately advance to the next turn, but this should make it easier to display messages in a logical order in these states.